### PR TITLE
Improve measurement fallbacks for movement segments

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -426,37 +426,151 @@ class MovementHighlighter {
     const grid = canvas.grid;
     if (!grid) return Infinity;
 
-    const RayClass = foundry?.canvas?.geometry?.Ray ?? window?.Ray;
+    const RayClass =
+      foundry?.canvas?.geometry?.Ray ??
+      foundry?.utils?.Ray ??
+      window?.Ray;
     if (!RayClass) return Infinity;
 
     const ray = new RayClass(from, to);
     const units = Number(canvas.dimensions?.distance ?? canvas.scene?.grid?.distance) || 5;
 
-    try {
-      if (typeof grid.measurePath === "function") {
-        const measurement = grid.measurePath({ ray, token, gridSpaces: true });
-        let dist;
-        if (Array.isArray(measurement)) {
-          const entry = measurement[0];
-          dist = typeof entry === "number" ? entry : entry?.distance ?? entry?.gridDistance ?? entry?.totalDistance;
-        } else if (typeof measurement === "number") {
-          dist = measurement;
-        } else if (measurement && typeof measurement === "object") {
-          dist = measurement.distance ?? measurement.gridDistance ?? measurement.totalDistance;
+    const parseDistance = (measurement) => {
+      if (typeof measurement === "number") return measurement;
+      if (Array.isArray(measurement)) {
+        for (const entry of measurement) {
+          const parsed = parseDistance(entry);
+          if (Number.isFinite(parsed)) return parsed;
         }
-        if (Number.isFinite(dist)) return dist * units;
+        return undefined;
       }
+      if (measurement && typeof measurement === "object") {
+        const candidates = [
+          measurement.distance,
+          measurement.gridDistance,
+          measurement.totalDistance,
+          measurement.value,
+          measurement.measure,
+          measurement.length,
+          measurement.spaces,
+          measurement.cells
+        ];
+        for (const candidate of candidates) {
+          const numeric = typeof candidate === "number" ? candidate : Number(candidate);
+          if (Number.isFinite(numeric)) return numeric;
+        }
+        return undefined;
+      }
+      return undefined;
+    };
 
-      if (typeof grid.measureDistances === "function") {
-        const distances = grid.measureDistances([{ ray }], { gridSpaces: true, token });
-        const dist = Number(Array.isArray(distances) ? distances[0] : distances);
-        if (Number.isFinite(dist)) return dist * units;
+    const baseOptions = {
+      token,
+      gridSpaces: true,
+      // Provide both naming conventions so whichever Foundry build is in use
+      // can derive offsets without throwing errors.
+      origin: from,
+      destination: to,
+      from,
+      to
+    };
+
+    let gridSpaces;
+    let lastError;
+
+    if (typeof grid.measurePath === "function") {
+      try {
+        const measurement = grid.measurePath.length > 1
+          ? grid.measurePath(ray, baseOptions)
+          : grid.measurePath({ ...baseOptions, ray });
+        gridSpaces = parseDistance(measurement);
+      } catch (err) {
+        lastError = err;
+        console.debug(`${MODULE_ID} | measurePath failed, falling back`, err);
       }
-    } catch (err) {
-      console.error(`${MODULE_ID} | Failed to measure segment`, err);
+    }
+
+    if (!Number.isFinite(gridSpaces) && typeof grid.measureDistances === "function") {
+      try {
+        const segments = [{ ray, from, to, token }];
+        const distances = grid.measureDistances(segments, baseOptions);
+        gridSpaces = parseDistance(distances);
+      } catch (err) {
+        lastError = err;
+        console.debug(`${MODULE_ID} | measureDistances failed, falling back`, err);
+      }
+    }
+
+    if (!Number.isFinite(gridSpaces) && typeof grid.measureDistance === "function") {
+      try {
+        const distance = grid.measureDistance(from, to, baseOptions);
+        gridSpaces = parseDistance(distance);
+      } catch (err) {
+        lastError = err;
+        console.debug(`${MODULE_ID} | measureDistance failed, falling back`, err);
+      }
+    }
+
+    if (!Number.isFinite(gridSpaces) && typeof canvas.grid?.measureDistance === "function" && canvas.grid.measureDistance !== grid.measureDistance) {
+      try {
+        const distance = canvas.grid.measureDistance(from, to, baseOptions);
+        gridSpaces = parseDistance(distance);
+      } catch (err) {
+        lastError = err;
+        console.debug(`${MODULE_ID} | canvas.grid.measureDistance failed, falling back`, err);
+      }
+    }
+
+    if (Number.isFinite(gridSpaces)) {
+      return gridSpaces * units;
+    }
+
+    const estimated = this._estimateGridDistance(from, to);
+    if (Number.isFinite(estimated)) {
+      return estimated * units;
+    }
+
+    if (lastError) {
+      console.error(`${MODULE_ID} | Failed to measure segment`, lastError);
     }
 
     return Infinity;
+  }
+
+  _estimateGridDistance(from, to) {
+    const size = Number(canvas.dimensions?.size);
+    if (!Number.isFinite(size) || size <= 0) return undefined;
+
+    const dx = Math.abs((to?.x ?? 0) - (from?.x ?? 0)) / size;
+    const dy = Math.abs((to?.y ?? 0) - (from?.y ?? 0)) / size;
+    if (!Number.isFinite(dx) || !Number.isFinite(dy)) return undefined;
+
+    const rules = CONST?.GRID_DIAGONAL_RULES ?? {};
+    const rule = canvas.grid?.diagonalRule ?? canvas.scene?.grid?.diagonalRule;
+
+    const matchesRule = (...candidates) => candidates.some((candidate) => candidate !== undefined && candidate === rule);
+
+    if (matchesRule(rules.MANHATTAN, "MANHATTAN")) {
+      return dx + dy;
+    }
+
+    if (matchesRule(rules.EUCLIDEAN, "EUCLIDEAN")) {
+      return Math.hypot(dx, dy);
+    }
+
+    if (matchesRule(rules.ROOFTOP, "ROOFTOP")) {
+      return Math.max(dx, dy);
+    }
+
+    if (matchesRule(rules.APPROXIMATION, "APPROXIMATION", "5105")) {
+      const diagonals = Math.min(dx, dy);
+      const straights = Math.abs(dx - dy);
+      return diagonals + straights + Math.floor(diagonals / 2);
+    }
+
+    const diagonals = Math.min(dx, dy);
+    const straights = Math.abs(dx - dy);
+    return diagonals + straights;
   }
 
   /**


### PR DESCRIPTION
## Summary
- restructure segment measurement to support multiple grid API signatures and avoid throwing errors
- add layered fallbacks, including heuristic distance estimation, when built-in measurements fail

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d775561350832799b64469cefc38f8