### PR TITLE
Improve measurement fallback and add toggleable debug logging

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -30,6 +30,10 @@
       "cellLimit": {
         "Name": "Cell exploration limit",
         "Hint": "Maximum number of grid cells to explore when searching for reachable positions. Higher values may impact performance."
+      },
+      "debugEnabled": {
+        "Name": "Enable debug logging",
+        "Hint": "Write detailed diagnostic information to the browser console to help troubleshoot measurement issues."
       }
     },
     "Notifications": {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -7,6 +7,35 @@
  * grid API.
  */
 const MODULE_ID = "easy-grid-movement";
+const SETTINGS = {
+  debugEnabled: "debugEnabled"
+};
+
+const formatMessage = (message) => `${MODULE_ID} | ${message}`;
+
+const callConsole = (fn, ...args) => {
+  if (typeof fn === "function") {
+    fn.call(console, ...args);
+  }
+};
+
+const isDebugEnabled = () => {
+  try {
+    return Boolean(game?.settings?.get?.(MODULE_ID, SETTINGS.debugEnabled));
+  } catch (err) {
+    warnLog("Unable to read debug setting", err);
+    return false;
+  }
+};
+
+const debugLog = (message, ...args) => {
+  if (!isDebugEnabled()) return;
+  callConsole(console.debug ?? console.log, formatMessage(message), ...args);
+};
+
+const infoLog = (message, ...args) => callConsole(console.info ?? console.log, formatMessage(message), ...args);
+const warnLog = (message, ...args) => callConsole(console.warn ?? console.log, formatMessage(message), ...args);
+const errorLog = (message, ...args) => callConsole(console.error ?? console.log, formatMessage(message), ...args);
 
 const LAYER_NAMES = {
   normal: `${MODULE_ID}-normal`,
@@ -160,7 +189,7 @@ class MovementHighlighter {
       try {
         this.refresh();
       } catch (err) {
-        console.error(`${MODULE_ID} | Failed to refresh highlights (${reason})`, err);
+        errorLog(`Failed to refresh highlights (${reason})`, err);
       }
     }, 150);
   }
@@ -314,13 +343,13 @@ class MovementHighlighter {
       try {
         startOffset = grid.getOffset(centerPoint, { round: true });
       } catch (err) {
-        console.debug(`${MODULE_ID} | getOffset failed`, err);
+        debugLog("getOffset failed", err);
       }
     } else if (typeof grid.grid?.getOffset === "function") {
       try {
         startOffset = grid.grid.getOffset(centerPoint, { round: true });
       } catch (err) {
-        console.debug(`${MODULE_ID} | inner getOffset failed`, err);
+        debugLog("inner getOffset failed", err);
       }
     }
 
@@ -420,43 +449,210 @@ class MovementHighlighter {
         if (collision) return Infinity;
       }
     } catch (err) {
-      console.debug(`${MODULE_ID} | Collision check failed`, err);
+      debugLog("Collision check failed", err);
     }
 
     const grid = canvas.grid;
     if (!grid) return Infinity;
 
-    const RayClass = foundry?.canvas?.geometry?.Ray ?? window?.Ray;
+    const RayClass =
+      foundry?.canvas?.geometry?.Ray ??
+      foundry?.utils?.Ray ??
+      window?.Ray;
     if (!RayClass) return Infinity;
 
     const ray = new RayClass(from, to);
     const units = Number(canvas.dimensions?.distance ?? canvas.scene?.grid?.distance) || 5;
 
-    try {
-      if (typeof grid.measurePath === "function") {
-        const measurement = grid.measurePath({ ray, token, gridSpaces: true });
-        let dist;
-        if (Array.isArray(measurement)) {
-          const entry = measurement[0];
-          dist = typeof entry === "number" ? entry : entry?.distance ?? entry?.gridDistance ?? entry?.totalDistance;
-        } else if (typeof measurement === "number") {
-          dist = measurement;
-        } else if (measurement && typeof measurement === "object") {
-          dist = measurement.distance ?? measurement.gridDistance ?? measurement.totalDistance;
+    const parseDistance = (measurement) => {
+      if (typeof measurement === "number") return measurement;
+      if (Array.isArray(measurement)) {
+        for (const entry of measurement) {
+          const parsed = parseDistance(entry);
+          if (Number.isFinite(parsed)) return parsed;
         }
-        if (Number.isFinite(dist)) return dist * units;
+        return undefined;
       }
+      if (measurement && typeof measurement === "object") {
+        const candidates = [
+          measurement.distance,
+          measurement.gridDistance,
+          measurement.totalDistance,
+          measurement.value,
+          measurement.measure,
+          measurement.length,
+          measurement.spaces,
+          measurement.cells
+        ];
+        for (const candidate of candidates) {
+          const numeric = typeof candidate === "number" ? candidate : Number(candidate);
+          if (Number.isFinite(numeric)) return numeric;
+        }
+        return undefined;
+      }
+      return undefined;
+    };
 
-      if (typeof grid.measureDistances === "function") {
-        const distances = grid.measureDistances([{ ray }], { gridSpaces: true, token });
-        const dist = Number(Array.isArray(distances) ? distances[0] : distances);
-        if (Number.isFinite(dist)) return dist * units;
+    const baseOptions = {
+      token,
+      gridSpaces: true,
+      // Provide both naming conventions so whichever Foundry build is in use
+      // can derive offsets without throwing errors.
+      origin: from,
+      destination: to,
+      from,
+      to
+    };
+
+    let gridSpaces;
+    let lastError;
+
+    const hasMeasurePath = typeof grid.measurePath === "function";
+    if (hasMeasurePath) {
+      const attempts = [
+        () => grid.measurePath({ ...baseOptions, ray })
+      ];
+      attempts.push(() => grid.measurePath(ray, baseOptions));
+      attempts.push(() => grid.measurePath([{ ray }], baseOptions));
+      attempts.push(() => grid.measurePath([ray], baseOptions));
+      attempts.push(() => grid.measurePath([ray]));
+
+      for (const attempt of attempts) {
+        try {
+          const measurement = attempt();
+          gridSpaces = parseDistance(measurement);
+          if (Number.isFinite(gridSpaces)) {
+            debugLog(
+              "measurePath succeeded (%o -> %o) => %s",
+              from,
+              to,
+              gridSpaces
+            );
+            break;
+          }
+          debugLog("measurePath attempt returned non-numeric result", measurement);
+        } catch (err) {
+          lastError = err;
+          debugLog("measurePath attempt failed", err);
+        }
       }
-    } catch (err) {
-      console.error(`${MODULE_ID} | Failed to measure segment`, err);
+    }
+
+    if (
+      !Number.isFinite(gridSpaces) &&
+      !hasMeasurePath &&
+      typeof grid.measureDistances === "function"
+    ) {
+      try {
+        const segments = [{ ray, from, to, token }];
+        const distances = grid.measureDistances(segments, baseOptions);
+        gridSpaces = parseDistance(distances);
+        if (Number.isFinite(gridSpaces)) {
+          debugLog(
+            "measureDistances succeeded (%o -> %o) => %s",
+            from,
+            to,
+            gridSpaces
+          );
+        }
+      } catch (err) {
+        lastError = err;
+        debugLog("measureDistances failed", err);
+      }
+    }
+
+    if (!Number.isFinite(gridSpaces) && typeof grid.measureDistance === "function") {
+      try {
+        const distance = grid.measureDistance(from, to, baseOptions);
+        gridSpaces = parseDistance(distance);
+        if (Number.isFinite(gridSpaces)) {
+          debugLog(
+            "measureDistance succeeded (%o -> %o) => %s",
+            from,
+            to,
+            gridSpaces
+          );
+        }
+      } catch (err) {
+        lastError = err;
+        debugLog("measureDistance failed", err);
+      }
+    }
+
+    if (!Number.isFinite(gridSpaces) && typeof canvas.grid?.measureDistance === "function" && canvas.grid.measureDistance !== grid.measureDistance) {
+      try {
+        const distance = canvas.grid.measureDistance(from, to, baseOptions);
+        gridSpaces = parseDistance(distance);
+        if (Number.isFinite(gridSpaces)) {
+          debugLog(
+            "canvas.grid.measureDistance succeeded (%o -> %o) => %s",
+            from,
+            to,
+            gridSpaces
+          );
+        }
+      } catch (err) {
+        lastError = err;
+        debugLog("canvas.grid.measureDistance failed", err);
+      }
+    }
+
+    if (Number.isFinite(gridSpaces)) {
+      return gridSpaces * units;
+    }
+
+    const estimated = this._estimateGridDistance(from, to);
+    if (Number.isFinite(estimated)) {
+      debugLog(
+        "Using heuristic measurement (%o -> %o) => %s",
+        from,
+        to,
+        estimated
+      );
+      return estimated * units;
+    }
+
+    if (lastError) {
+      errorLog("Failed to measure segment", lastError);
     }
 
     return Infinity;
+  }
+
+  _estimateGridDistance(from, to) {
+    const size = Number(canvas.dimensions?.size);
+    if (!Number.isFinite(size) || size <= 0) return undefined;
+
+    const dx = Math.abs((to?.x ?? 0) - (from?.x ?? 0)) / size;
+    const dy = Math.abs((to?.y ?? 0) - (from?.y ?? 0)) / size;
+    if (!Number.isFinite(dx) || !Number.isFinite(dy)) return undefined;
+
+    const rules = CONST?.GRID_DIAGONAL_RULES ?? {};
+    const rule = canvas.grid?.diagonalRule ?? canvas.scene?.grid?.diagonalRule;
+
+    const matchesRule = (...candidates) => candidates.some((candidate) => candidate !== undefined && candidate === rule);
+
+    if (matchesRule(rules.MANHATTAN, "MANHATTAN")) {
+      return dx + dy;
+    }
+
+    if (matchesRule(rules.EUCLIDEAN, "EUCLIDEAN")) {
+      return Math.hypot(dx, dy);
+    }
+
+    if (matchesRule(rules.ROOFTOP, "ROOFTOP")) {
+      return Math.max(dx, dy);
+    }
+
+    if (matchesRule(rules.APPROXIMATION, "APPROXIMATION", "5105")) {
+      const diagonals = Math.min(dx, dy);
+      const straights = Math.abs(dx - dy);
+      return diagonals + straights + Math.floor(diagonals / 2);
+    }
+
+    const diagonals = Math.min(dx, dy);
+    const straights = Math.abs(dx - dy);
+    return diagonals + straights;
   }
 
   /**
@@ -497,7 +693,7 @@ class MovementHighlighter {
       try {
         layer = gridInterface.addHighlightLayer(name);
       } catch (err) {
-        console.error(`${MODULE_ID} | Failed to add highlight layer ${name}`, err);
+        errorLog(`Failed to add highlight layer ${name}`, err);
       }
     }
     if (layer) layer.alpha = alpha;
@@ -530,7 +726,7 @@ class MovementHighlighter {
         layer.drawPolygon(shape);
         layer.endFill();
       } catch (drawErr) {
-        console.error(`${MODULE_ID} | Failed to draw highlight`, drawErr);
+        errorLog("Failed to draw highlight", drawErr);
       }
     }
   }
@@ -683,7 +879,7 @@ class MovementHighlighter {
       try {
         offsets = grid.getAdjacentOffsets();
       } catch (err) {
-        console.debug(`${MODULE_ID} | getAdjacentOffsets failed`, err);
+        debugLog("getAdjacentOffsets failed", err);
       }
     }
     if (!Array.isArray(offsets) || !offsets.length) {
@@ -715,7 +911,7 @@ class MovementHighlighter {
       try {
         gridInterface.clearHighlightLayer(name);
       } catch (err) {
-        console.debug(`${MODULE_ID} | Failed to clear highlight layer ${name}`, err);
+        debugLog(`Failed to clear highlight layer ${name}`, err);
       }
     }
   }
@@ -855,6 +1051,22 @@ function registerSettings() {
     default: DEFAULTS.cellLimit,
     range: { min: 500, max: 20000, step: 100 },
     onChange: () => highlighter?.onSettingsChanged()
+  });
+
+  game.settings.register(MODULE_ID, SETTINGS.debugEnabled, {
+    name: game.i18n.localize("EGM.Settings.debugEnabled.Name"),
+    hint: game.i18n.localize("EGM.Settings.debugEnabled.Hint"),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: (value) => {
+      if (value) {
+        infoLog("Debug logging enabled");
+      } else {
+        infoLog("Debug logging disabled");
+      }
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- add reusable logging helpers and a client setting to enable debug output on demand
- retry multiple SquareGrid#measurePath signatures before falling back to legacy APIs to avoid deprecation warnings
- gate all diagnostic output behind the new debug logger and keep error reporting consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d775561350832799b64469cefc38f8