### PR TITLE
Normalize neighbor offsets from Foundry

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -753,22 +753,16 @@ class MovementHighlighter {
       const num = Number(value);
       return Number.isFinite(num) ? num : 0;
     };
-    const getValue = (offset, keys, index) => {
-      if (!offset) return 0;
-      for (const key of keys) {
-        const candidate = offset?.[key];
-        if (candidate !== undefined && candidate !== null) return candidate;
-      }
-      if (Array.isArray(offset)) {
-        const candidate = offset[index];
-        if (candidate !== undefined && candidate !== null) return candidate;
-      }
-      return 0;
-    };
-    this._neighborOffsets = offsets.map((offset) => ({
-      x: toNumber(getValue(offset, ["x", "i", "column"], 0)),
-      y: toNumber(getValue(offset, ["y", "j", "row"], 1))
-    }));
+    this._neighborOffsets = offsets.map((offset) => {
+      const xValue =
+        offset?.x ?? offset?.i ?? offset?.column ?? offset?.[0] ?? (Array.isArray(offset) ? offset[0] : 0);
+      const yValue =
+        offset?.y ?? offset?.j ?? offset?.row ?? offset?.[1] ?? (Array.isArray(offset) ? offset[1] : 0);
+      return {
+        x: toNumber(xValue),
+        y: toNumber(yValue)
+      };
+    });
     return this._neighborOffsets;
   }
 


### PR DESCRIPTION
## Summary
- normalize neighbor offsets returned by Foundry to support multiple property shapes
- coerce offset components to numeric values before caching neighbor data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d851d1f5a48327a57994fa7fd85c4a